### PR TITLE
[CDS-385] ECs-EC2 Prometheus Auto Discovery

### DIFF
--- a/prometheus/ecs-ec2/autodiscovery/README.md
+++ b/prometheus/ecs-ec2/autodiscovery/README.md
@@ -1,0 +1,130 @@
+# Prometheus on ECS-EC2 with Auto-Discovery
+
+This cloudformation template deploys the CWAgent and Prometheus Node Exporter on an ECS EC2 Cluster. The Cloudwatch Agent is configured with auto-discover to detect Prometheus scrape endpoints and store them in a a file. The Promotheus node exporter is configured to scrape the endpoints discovered by the Cloudwatch Agent from the file.
+
+```
++---------------------------------------------+
+|   ECS Cluster                               |
+|                                             |
+|                        Scan cluster for     |
+| +-------------------+  Prometheus targets   |
+| |                   |---------------------+ |
+| |   CloudWatch      |                       |
+| |     Agents        |<--------------------+ |
+| |                   |                       |
+| +-------------------+                       |
+|             |                               |
+|             |  Store targets                |
+|             V                               |
+| +----------------------------------+        |
+| | Prometheus Scrape Endpoints File |        |
+| +----------------------------------+        |
+|             ^                               |
+|             | Uses                          |
+| +------------------+                        |
+| |                  |                        |
+| | Prometheus Node  |   -------------------------> [Coralogix]
+| |     Exporter     |                        |
+| |                  |                        |
+| +------------------+                        |
+|             |                               |
+|             | Scrapes                       |
+|             V                               |
+| +--------------------+                      |
+| | Prometheus Targets |                      |
+| +--------------------+                      |
+|                                             |
++---------------------------------------------+
+
+
+```
+
+##### Requires:
+
+In order for a Prometheus target container to be detected by the Cloudwatch Agent, the container must be annotated with the following __Docker labels__:
+
+| Label | Description | Default |
+| --- | --- | --- |
+| ECS_PROMETHEUS_EXPORTER_PORT | The Prometheus exporter port | "9090" |
+| ECS_PROMETHEUS_METRICS_PATH | The Prometheus expoert metric path | "/metrics" |
+
+
+
+##### Parameters:
+
+| Parameter | Description | Type | Default | Required |
+|---|---|---|---|---|
+| ECSClusterName | Enter the name of your ECS cluster from which you want to collect Prometheus metrics | String | | ✔️ |
+| CreateIAMRoles | Whether to create new IAM roles or use an existing IAM roles for the ECS tasks | String | `True` | |
+| ECSNetworkMode | ECS Network Mode for the Task | String | `bridge` | |
+| TaskRoleName | Enter the CloudWatch Agent ECS task role name | String | `ECSDiscoveryCWAgentTaskRoleName` | |
+| ExecutionRoleName | Enter the CloudWatch Agent ECS execution role name | String | `ECSDiscoveryCWAgentExecutionRoleName` | |
+| CoralogixRegion | The Coralogix location region | String | `Europe` | ✔️ |
+| CoralogixPrivateKey | The Coralogix Private Key | String | `NoEcho: true` | ✔️ |
+| PrometheusNodeExporterImage | The Prometheus Node Exporter Image | String | `prom/node-exporter:v1.0.1` | |
+
+
+##### Deploy
+
+```
+aws cloudformation deploy --template-file template.yaml \
+    --stack-name prometheus-ecs-ec2-autodiscovery \
+    --region <region> \
+    --parameter-overrides \
+        ECSClusterName=<your cluster name> \
+        CoralogixPrivateKey=<your-private-key> \
+        CoralogixRegion=<your-region> \
+    --capabilities CAPABILITY_NAMED_IAM
+```
+
+
+##### Validation
+
+The Cloudwatch Agent will store the Prometheus scrape endpoints in the file: `/tmp/cwagent_ecs_auto_sd.yaml`. The file will be mounted to the container from the host. You can check the contents of the file to verify that the Prometheus scrape endpoints are being discovered.
+
+The contents should look similar to the following:
+
+```yaml
+- targets:
+  - 10.0.0.127:32768
+  labels:
+    __metrics_path__: /metrics
+    ECS_PROMETHEUS_EXPORTER_PORT: "9090"
+    ECS_PROMETHEUS_METRICS_PATH: /metrics
+    InstanceType: t2.large
+    LaunchType: EC2
+    StartedBy: ecs-svc/7562722944147020298
+    SubnetId: subnet-076f1018de94369dd
+    TaskClusterName: cds-305
+    TaskDefinitionFamily: prometheus-task-definition
+    TaskGroup: service:prometheus-service
+    TaskId: 07f62e85057342cc916c27e7232b9546
+    TaskRevision: "10"
+    VpcId: vpc-02bbde9df35cf5d95
+    container_name: prometheus
+- targets:
+  - 10.0.1.77:32902
+  labels:
+    __metrics_path__: /metrics
+    ECS_PROMETHEUS_EXPORTER_PORT: "9090"
+    ECS_PROMETHEUS_METRICS_PATH: /metrics
+    InstanceType: t2.large
+    LaunchType: EC2
+    StartedBy: ecs-svc/7562722944147020298
+    SubnetId: subnet-0445660746d6d06b4
+    TaskClusterName: cds-305
+    TaskDefinitionFamily: prometheus-task-definition
+    TaskGroup: service:prometheus-service
+    TaskId: 43479e93fa184e24bbf0ddf0e42c6cd2
+    TaskRevision: "10"
+    VpcId: vpc-02bbde9df35cf5d95
+    container_name: prometheus
+```
+
+By default the Prometheus Node Export is configured to send to Coralogix. You can also verify that the Prometheus scrape endpoints are being scraped by checking the Coralogix console.
+
+---
+
+This template is meant to be a starting point for leveraging the CW Agent for Prometheus Auto Discovery in ECS-EC2 using Docker Labels, it is also possible to detect prometheus endpoints using Task Definition ARN patterns.
+
+For more information on additional configurations and features, please reference the [AWS Docuementation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Setup-autodiscovery-ecs.html).

--- a/prometheus/ecs-ec2/autodiscovery/template.yaml
+++ b/prometheus/ecs-ec2/autodiscovery/template.yaml
@@ -1,0 +1,288 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ECSClusterName:
+    Type: String
+    Description: Enter the name of your ECS cluster from which you want to collect Prometheus metrics
+  
+  CreateIAMRoles:
+    Type: String
+    Default: 'True'
+    Description: |
+      Whether to create new IAM roles or use an existing IAM roles for the ECS tasks
+      If 'False', you must specify both the TaskRoleName and ExecutionRoleName parameters
+
+    ConstraintDescription: must specifid, either True or False
+    AllowedValues:
+      - 'True'
+      - 'False'
+
+  ECSNetworkMode:
+    Type: String
+    Default: bridge
+    Description: ECS Network Mode for the Task
+    AllowedValues:
+      - 'bridge'
+      - 'host'
+    
+  TaskRoleName:
+    Type: String
+    Description: |
+      Enter the CloudWatch Agent ECS task role name
+      The CreateRole parameter must be set to 'False' when using this value
+    Default: ECSDiscoveryCWAgentTaskRoleName
+
+  ExecutionRoleName:
+    Type: String
+    Description: | 
+      Enter the CloudWatch Agent ECS execution role name. 
+      The CreateRole parameter must be set to 'False' when using this value
+    Default: ECSDiscoveryCWAgentExecutionRoleName
+
+  CoralogixRegion:
+      Type: String
+      Description: The Coralogix location region
+      AllowedValues:
+        - Europe
+        - Europe2
+        - India
+        - Singapore
+        - US
+
+  CoralogixPrivateKey:
+    Type: String
+    Description: The Coralogix Private Key
+    NoEcho: true
+
+  PrometheusNodeExporterImage:
+    Type: String
+    Description: |
+      The Prometheus Node Exporter Image, note, only supports v0.0.3+
+      https://hub.docker.com/r/coralogixrepo/prometheus-node-exporter-ecs/tags
+    Default: coralogixrepo/prometheus-node-exporter-ecs:0.0.3
+
+Conditions:
+  CreateRoles: !Equals 
+      - !Ref CreateIAMRoles
+      - 'True'
+
+Mappings:
+  CoralogixRegionMap:
+    Europe:
+      Endpoint: ingress.coralogix.com:443
+      Domain: coralogix.com
+      RemoteWrite: https://ingress.coralogix.com/prometheus/v1
+    Europe2:
+      Endpoint: ingress.eu2.coralogix.com:443
+      Domain: eu2.coralogix.com
+      RemoteWrite: https://ingress.eu2.coralogix.com/prometheus/v1
+    India:
+      Endpoint: ingress.coralogix.in:443
+      Domain: coralogix.in
+      RemoteWrite: https://ingress.coralogix.in/prometheus/v1
+    Singapore:
+      Endpoint: ingress.coralogixsg.com:443
+      Domain: coralogixsg.com
+      RemoteWrite: https://ingress.coralogixsg.com/prometheus/v1
+    US:
+      Endpoint: ingress.coralogix.us:443
+      Domain: coralogix.us
+      RemoteWrite: https://ingress.coralogix.us/prometheus/v1
+
+Resources:
+  # The Promtheus Config for the CLoudWatch Agent
+  # note that this scrape config is technically not used needed
+  # as we will be adding a separate prometheus instance to scrape
+  CWPrometheusConfigSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub 'AmazonCloudWatch-PrometheusConfigName-${ECSClusterName}-EC2-${ECSNetworkMode}'
+      Type: String
+      Tier: Standard
+      Description: !Sub 'Prometheus Scraping SSM Parameter for ECS Cluster: ${ECSClusterName}'
+      Value: |
+        global:
+          scrape_interval: 1m
+          scrape_timeout: 10s
+
+        scrape_configs:
+          - job_name: cwagent-ecs-file-sd-config
+            sample_limit: 10000
+            file_sd_configs:
+              - files: [ "/tmp/cwagent_ecs_auto_sd.yaml" ]
+
+  # The CloudWatch Agent Config for detecting Prometheus Exporters
+  CWAgentConfigSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub 'AmazonCloudWatch-CWAgentConfig-${ECSClusterName}-EC2-${ECSNetworkMode}'
+      Type: String
+      Tier: Intelligent-Tiering
+      Description: !Sub 'CWAgent SSM Parameter with App Mesh and Java EMF Definition for ECS Cluster: ${ECSClusterName}'
+      Value: |
+        { 
+          "logs": {
+            "metrics_collected": {
+              "prometheus": {
+                "prometheus_config_path": "env:PROMETHEUS_CONFIG_CONTENT",
+                "ecs_service_discovery": {
+                  "sd_frequency": "1m",
+                  "sd_result_file": "/tmp/cwagent_ecs_auto_sd.yaml",
+                  "docker_label": {
+                    "sd_port_label": "ECS_PROMETHEUS_EXPORTER_PORT"
+                  }
+                }
+              }
+            },
+            "force_flush_interval": 5
+          }
+        }
+
+  CWAgentECSExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      RoleName: !Ref ExecutionRoleName
+      Description: Allows ECS container agent makes calls to the Amazon ECS API on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Policies:
+        - PolicyName: ECSSSMInlinePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameters
+                Resource: arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*
+
+  CWAgentECSTaskRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    DependsOn: CWAgentECSExecutionRole
+    Properties:
+      RoleName: !Ref TaskRoleName
+      Description: Allows ECS tasks to call AWS services on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Policies:
+        - PolicyName: ECSServiceDiscoveryInlinePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecs:DescribeTasks
+                  - ecs:ListTasks
+                  - ecs:DescribeContainerInstances
+                Resource: "*"
+                Condition:
+                  ArnEquals:
+                    ecs:cluster:
+                      !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ECSClusterName}'
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ecs:DescribeTaskDefinition
+                Resource: "*"
+
+  ECSCWAgentTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      Family: !Sub 'cwagent-prometheus-${ECSClusterName}-EC2-${ECSNetworkMode}'
+      TaskRoleArn: !If [CreateRoles, !GetAtt CWAgentECSTaskRole.Arn, !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${TaskRoleName}']
+      ExecutionRoleArn: !If [CreateRoles, !GetAtt  CWAgentECSExecutionRole.Arn, !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${ExecutionRoleName}']
+      NetworkMode: !Ref ECSNetworkMode
+      Volumes:
+        - Name: tmp
+          Host:
+            SourcePath: "/tmp"
+
+      ContainerDefinitions:
+        - Name: cloudwatch-agent-prometheus
+          Image: amazon/cloudwatch-agent:latest
+          Essential: true
+
+          MountPoints:
+            - SourceVolume: tmp
+              ContainerPath: "/tmp"
+
+          Secrets:
+            - Name: PROMETHEUS_CONFIG_CONTENT
+              ValueFrom: !Ref CWPrometheusConfigSSMParameter
+            - Name: CW_CONFIG_CONTENT
+              ValueFrom: !Ref CWAgentConfigSSMParameter
+
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: "/ecs/ecs-cwagent-prometheus"
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: !Sub 'ecs-EC2-${ECSNetworkMode}'
+
+        - Name: "prometheus-exporter"
+          Image: !Ref PrometheusNodeExporterImage
+          Essential: true
+          Memory: 300
+          Cpu: 10
+          PortMappings:
+            - ContainerPort: 9090
+              Protocol: tcp
+
+          MountPoints:
+            - SourceVolume: tmp
+              ContainerPath: "/tmp"
+              ReadOnly: true
+               
+          Environment:
+            - Name: "SCRAPE_CONFIG"
+              Value: !Sub
+                - |
+                    global:
+                      scrape_interval: 1m
+                      scrape_timeout: 10s
+
+                    scrape_configs:
+                      - job_name: cwagent-ecs-file-sd-config
+                        sample_limit: 10000
+                        file_sd_configs:
+                          - files: [ "/tmp/cwagent_ecs_auto_sd.yaml" ]
+
+                    remote_write:
+                      - url: '${endpoint}'
+                        name: 'crx'
+                        remote_timeout: 120s
+                        bearer_token: '${token}'
+
+                - endpoint: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, RemoteWrite]
+                  token: !Ref CoralogixPrivateKey
+
+      RequiresCompatibilities:
+        - EC2
+      Cpu: '512'
+      Memory: '1024'
+
+  ECSCWAgentService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref ECSClusterName
+      DesiredCount: 1
+      LaunchType: EC2
+      SchedulingStrategy: REPLICA
+      ServiceName: !Sub 'cwagent-prometheus-replica-service-EC2-${ECSNetworkMode}'
+      TaskDefinition: !Ref ECSCWAgentTaskDefinition


### PR DESCRIPTION
This PR adds an example template of setting up the Cloudwatch Agent to automatically detect prometheus scrape endpoints. It also adds a central prometheus scraper that scrapes all the detected endpoints.
